### PR TITLE
Allow adding images to docx inline

### DIFF
--- a/app/helpers/consoleHelper.js
+++ b/app/helpers/consoleHelper.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// note that this is used by adding ".red", ".underline", etc to any string,
+// e.g. mystring.red or "some string".underline. As such eslint doesn't detect
+// it being used.
+const colors = require('colors'); // eslint-disable-line no-unused-vars
+
+function formatText(messages, title, color, addSpacing) {
+
+	let output = '',
+		prefix = '';
+
+	if (typeof messages === 'string') {
+		messages = [messages]; // make it an array
+	} else if (!Array.isArray(messages)) {
+		throw new Error('messages must be string or array');
+	}
+
+	if (title && typeof title === 'string') {
+		output += title[color].underline;
+	} else {
+		title = false;
+	}
+
+	if (messages.length > 1) {
+		prefix = ' - ';
+	}
+
+	for (let i = 0; i < messages.length; i++) {
+		messages[i] = `${prefix}${messages[i]}`[color];
+	}
+
+	if (messages.length > 1) {
+		if (title) {
+			output += '\n';
+		}
+		output += messages.join('\n');
+	} else {
+		if (title) {
+			output += ': '[color];
+		}
+		output += messages[0];
+	}
+
+	if (addSpacing) {
+		output = `\n${output}\n`;
+	}
+
+	return output;
+}
+
+module.exports = {
+
+	warn: function(messages, title, addSpacing = true) {
+		console.error(formatText(messages, title, 'red', addSpacing));
+	},
+
+	success: function(messages, title, addSpacing = false) {
+		console.error(formatText(messages, title, 'green', addSpacing));
+	}
+
+};

--- a/app/model/step.js
+++ b/app/model/step.js
@@ -38,6 +38,20 @@ module.exports = class Step {
 		// Check for images
 		if (stepYaml.images) {
 			this.images = arrayHelper.parseArray(stepYaml.images);
+
+			for (let i = 0; i < this.images.length; i++) {
+				if (typeof this.images[i] === 'string') {
+					this.images[i] = { path: this.images[i] };
+				}
+				const image = this.images[i];
+
+				if (image.width && !Number.isInteger(image.width) && image.width < 1) {
+					throw new Error('Width should be empty or a positive integery: {$image.path}');
+				}
+				if (image.height && !Number.isInteger(image.height) && image.height < 1) {
+					throw new Error('Height should be empty or a positive integery: {$image.path}');
+				}
+			}
 		}
 
 		// Check for checkboxes

--- a/app/schema/taskSchema.json
+++ b/app/schema/taskSchema.json
@@ -23,6 +23,24 @@
                                     {
                                         "type": "array",
                                         "items": {"type": "string"}
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
+                                            ,
+                                            "properties": {
+                                                "path": { "type": "string" },
+                                                "width": {
+                                                    "type": "number",
+                                                    "pattern": "^[0-9]+$"
+                                                },
+                                                "height": {
+                                                    "type": "number",
+                                                    "pattern": "^[0-9]+$"
+                                                }
+                                            }
+                                        }
                                     }
                                 ]
                             },
@@ -82,7 +100,7 @@
     "type": "object",
     "properties": {
         "title": { "type": "string" },
-        "duration": { 
+        "duration": {
             "type": "string",
             "pattern": "^[0-9]{2}:[0-9]{2}$"
         },
@@ -91,7 +109,7 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "simo": { 
+                    "simo": {
                         "type": "object",
                         "additionalProperties": { "$ref": "#/definitions/step" }
                     }

--- a/app/writer/Writer.js
+++ b/app/writer/Writer.js
@@ -5,6 +5,7 @@ const docx = require('docx');
 const childProcess = require('child_process');
 // const Series = require('../model/series');
 const DocxTableHandler = require('./DocxTableHandler');
+const consoleHelper = require('../helpers/consoleHelper');
 
 module.exports = class Writer {
 
@@ -130,6 +131,7 @@ module.exports = class Writer {
 	writeFile(filepath) {
 		docx.Packer.toBuffer(this.doc).then((buffer) => {
 			fs.writeFileSync(filepath, buffer);
+			consoleHelper.success(`${filepath} written!`);
 		});
 	}
 

--- a/eva-tasklist.js
+++ b/eva-tasklist.js
@@ -57,6 +57,7 @@ function run(args) {
 				console.logIfVerbose(procedure, 1, 3);
 
 				// genDocx...
+				console.log('Creating EVA format');
 				const threecoldocx = new ThreeColDocx(program, procedure);
 				threecoldocx.writeFile(path.join(
 					program.outputPath,
@@ -64,7 +65,7 @@ function run(args) {
 				));
 
 				if (program.sodf) {
-					console.log('Writing SODF form');
+					console.log('Creating SODF format');
 					const sodf = new SodfDocxWriter(program, procedure);
 					sodf.writeFile(path.join(
 						program.outputPath,

--- a/eva-tasklist.js
+++ b/eva-tasklist.js
@@ -267,6 +267,7 @@ function validateProgramArguments(program) {
 
 	program.procedurePath = path.join(program.projectPath, 'procedures');
 	program.tasksPath = path.join(program.projectPath, 'tasks');
+	program.imagesPath = path.join(program.projectPath, 'images');
 	program.outputPath = path.join(program.projectPath, 'build');
 	program.gitPath = path.join(program.projectPath, '.git');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,6 +2079,14 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "image-size": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.8.1.tgz",
+      "integrity": "sha512-X2HcWljsuWJPMTb1CGAN2+xuAAjQK5kdSzhqQXZlJBf0MpdXqfIeQCMJKYKS2OEVDwReS2zO5i7MlikWPBTotQ==",
+      "requires": {
+        "queue": "6.0.1"
+      }
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -3574,6 +3582,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "queue": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.1.tgz",
+      "integrity": "sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -635,6 +635,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    },
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "ajv": "^6.10.2",
     "bootstrap": "^4.3.1",
+    "colors": "^1.3.3",
     "commander": "^2.20.0",
     "docx": "^5.0.0-rc5",
     "filenamify": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "commander": "^2.20.0",
     "docx": "^5.0.0-rc5",
     "filenamify": "^4.1.0",
+    "image-size": "^0.8.1",
     "jquery": "^3.4.1",
     "js-beautify": "^1.10.2",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Now when this is added to a procedure:

```yaml
  - simo:
      SomeActor:
        - step: 'Do some things'
          images:
            - path: an_image.jpg
              height: 200
              width: 300 # don't actually specify both width AND height, see below
```

The relevant image is added inline above the step text. This was possible already using the HTML output format, but hadn't yet been added to docx format. 

Note that `height` and `width` are optional. ~If they are not provided a default width will be used, and the height will be calculated based upon the source images width/height ratio~. Likewise, if just `width` or `height` is provided, the other dimension will be calculate based upon the source image ratio. If both `width` and `height` are provided, the image will be sized accordingly, but may be distorted if the specified width/height do not have the same ratio as the source image. As such, just specifying one is probably better in most cases.

EDIT: Images without `width` or `height` specified no longer get scaled to a default width. Instead they are made to fit within a box of max width/height. If the source image already fits within that box, then no scaling is performed. If it is larger than that box then it will be scaled to fit.