### PR TITLE
Specify task duration by role

### DIFF
--- a/app/model/Duration.js
+++ b/app/model/Duration.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const consoleHelper = require('../helpers/consoleHelper');
+
+module.exports = class Duration {
+
+	/**
+	 * Constructor for Duration
+	 * @param {Object} duration  Ex: { minutes: 60, offset: { minutes: 15 } }
+	 * @param {bool} useOffset Whether or not to recurse and make a this.offset
+	 *                        Duration object.
+	 */
+	constructor(duration, useOffset = true) {
+
+		// allow creating a zero-time duration
+		if (!duration) {
+			duration = {};
+		}
+
+		const errors = [];
+		for (const t of ['hours', 'minutes', 'seconds']) {
+			if (duration[t] && !Number.isInteger(duration[t])) {
+				errors.push(`duration ${t} must be an integer`);
+			}
+
+			// e.g. set this.hours to duration.hours or zero
+			this[t] = duration[t] || 0;
+		}
+		if (errors.length > 0) {
+			consoleHelper.error(errors, 'Duration validation');
+		}
+
+		// roll any overflow of seconds into minutes
+		if (this.seconds > 59) {
+			this.minutes += Math.floor(this.seconds / 60);
+			this.seconds = this.seconds % 60;
+		}
+
+		// roll any overflow of minutes into hours
+		if (this.minutes > 59) {
+			this.hours += Math.floor(this.minutes / 60);
+			this.minutes = this.minutes % 60;
+		}
+
+		// don't set an offset of an offset because (a) that makes no sense and
+		// (b) infinite recursion.
+		if (useOffset) {
+			this.offset = new Duration(duration.offset, false);
+		}
+	}
+
+	getTotalHours() {
+		return this.hours + (this.minutes / 60) + (this.seconds / 3600);
+	}
+
+	getTotalMinutes() {
+		return (this.hours * 60) + this.minutes + (this.seconds / 60);
+	}
+
+	getTotalSeconds() {
+		return (this.hours * 3600) + (this.minutes * 60) + this.seconds;
+	}
+
+	toString() {
+		return this.format('H:M:S');
+	}
+
+	format(format) {
+		// String.padStart requires ES2017 but has a very simple polyfill if we
+		// ever want to run this in non-modern browsers
+		/* eslint-disable no-restricted-properties */
+		return format
+			.replace('H', this.hours.toString().padStart(2, '0'))
+			.replace('M', this.minutes.toString().padStart(2, '0'))
+			.replace('S', this.seconds.toString().padStart(2, '0'));
+		/* eslint-enable no-restricted-properties */
+	}
+};

--- a/app/model/TaskRole.js
+++ b/app/model/TaskRole.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const consoleHelper = require('../helpers/consoleHelper');
+const Duration = require('./Duration');
 
 module.exports = class TaskRole {
 
@@ -12,6 +13,7 @@ module.exports = class TaskRole {
 	constructor(roleDef, procTaskInstance) {
 		this.name = roleDef.name;
 		this.description = roleDef.description;
+		this.duration = new Duration(roleDef.duration);
 		if (!procTaskInstance || !procTaskInstance.roles || !procTaskInstance.roles[this.name]) {
 			consoleHelper.error([
 				'Roles defined within tasks must be filled by procedure actors',

--- a/app/model/task.js
+++ b/app/model/task.js
@@ -20,14 +20,9 @@ module.exports = class Task {
 		}
 		this.title = taskDefinition.title;
 
-		// Get the duration
-		if (!taskDefinition.duration) {
-			throw new Error(`Input YAML task missing duration: ${JSON.stringify(taskDefinition)}`);
-		}
-		this.duration = taskDefinition.duration;
-
 		if (taskDefinition.roles) {
-			this.roles = {};
+			this.rolesDict = {};
+			this.rolesArr = [];
 			for (const role of taskDefinition.roles) {
 				if (!role.name) {
 					consoleHelper.error([
@@ -35,7 +30,8 @@ module.exports = class Task {
 						role
 					], 'Task role definition error');
 				}
-				this.roles[role.name] = new TaskRole(role, proceduresTaskInstance);
+				this.rolesDict[role.name] = new TaskRole(role, proceduresTaskInstance);
+				this.rolesArr.push(this.rolesDict[role.name]);
 			}
 		}
 
@@ -45,7 +41,7 @@ module.exports = class Task {
 		}
 		this.concurrentSteps = [];
 		for (var concurrentStepYaml of taskDefinition.steps) {
-			this.concurrentSteps.push(new ConcurrentStep(concurrentStepYaml, this.roles));
+			this.concurrentSteps.push(new ConcurrentStep(concurrentStepYaml, this.rolesDict));
 		}
 
 		if (procedureColumnKeys) {

--- a/app/schema/taskSchema.json
+++ b/app/schema/taskSchema.json
@@ -100,9 +100,47 @@
     "type": "object",
     "properties": {
         "title": { "type": "string" },
-        "duration": {
-            "type": "string",
-            "pattern": "^[0-9]{2}:[0-9]{2}$"
+        "roles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "duration": {
+                        "type": "object",
+                        "properties": {
+                            "hours": {
+                                "type": "number",
+                                "pattern": "^[0-9]+$"
+                            },
+                            "minutes": {
+                                "type": "number",
+                                "pattern": "^[0-9]+$"
+                            },
+                            "offset": {
+                                "type": "object",
+                                "properties": {
+                                    "hours": {
+                                        "type": "number",
+                                        "pattern": "^[0-9]+$"
+                                    },
+                                    "minutes": {
+                                        "type": "number",
+                                        "pattern": "^[0-9]+$"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "required": ["name", "duration"]
+            }
+
         },
         "steps": {
             "type": "array",
@@ -118,5 +156,5 @@
             }
         }
     },
-    "required": ["title", "duration", "steps"]
+    "required": ["title", "roles", "steps"]
 }

--- a/app/writer/Writer.js
+++ b/app/writer/Writer.js
@@ -237,10 +237,27 @@ module.exports = class Writer {
 	}
 
 	genHeader(task) {
+
+		const durationDisplays = [];
+		let durationDisplay;
+
+		for (const role of task.rolesArr) {
+			durationDisplays.push(role.duration.format('H:M'));
+		}
+
+		// if all the duration displays are the same
+		if (durationDisplays.every((val, i, arr) => val === arr[0])) {
+			durationDisplay = durationDisplays[0];
+
+		// not the same, concatenate them
+		} else {
+			durationDisplay = durationDisplays.join(' / ');
+		}
+
 		return new docx.Header({
 			children: [new docx.Paragraph({
 				children: [new docx.TextRun({
-					text: `${this.procedure.name} - ${task.title} (${task.duration})`,
+					text: `${this.procedure.name} - ${task.title} (${durationDisplay})`,
 					bold: true,
 					size: 24, // half-points, so double the point height
 					font: {


### PR DESCRIPTION
Defining duration of a task now must be performed per-actor, like this:

```yaml
roles:

  - name: crewA
    description: Some description
    duration:
      minutes: 90

  - name: crewB
    duration:
      hours: 1
      minutes: 15
      offset:
        minutes: 15
```

These formats are **invalid** now:

```yaml
duration: "00:30"

duration:
  hours: 1
  minutes: 30
```

