### PR TITLE
Make --html output less broken; Needs to be rewritten

### DIFF
--- a/app/helpers/nunjucksHelper.js
+++ b/app/helpers/nunjucksHelper.js
@@ -32,7 +32,7 @@ function setCssFilename(filename) {
 /*
  * Create the html from the template file
  */
-function createHtml(evaTask, htmlFileTemplate, callback) {
+function createHtml(procedure, htmlFileTemplate, callback) {
 
 	// Get the directory and main template name
 	var templatePath = path.resolve(htmlFileTemplate);
@@ -101,10 +101,10 @@ function createHtml(evaTask, htmlFileTemplate, callback) {
 		return `${dir}/${imageName}`;
 	});
 
-	// Create the object passed into nunjucks from the evaTask and the css file
+	// Create the object passed into nunjucks from the procedure and the css file
 	// (if it exists)
 	var nunjucksObject = {
-		procedure: evaTask,
+		procedure: procedure,
 		version: ver.currentVersion
 	};
 

--- a/app/model/procedure.js
+++ b/app/model/procedure.js
@@ -132,6 +132,8 @@ module.exports = class Procedure {
      */
 	async populateFromFile(fileName) {
 
+		this.procedureFile = fileName;
+
 		try {
 
 			// Check if the file exists

--- a/eva-tasklist.js
+++ b/eva-tasklist.js
@@ -7,7 +7,6 @@
 const program = require('commander');
 const path = require('path');
 const fs = require('fs');
-const child = require('child_process');
 const pjson = require('./package.json');
 
 const ver = require('./app/helpers/versionHelper');
@@ -153,9 +152,9 @@ function buildProgramArguments(program, args) {
 			}
 			program.sodf = options.sodf;
 			program.html = options.html;
-			program.template = options.template
-				? options.template
-				: path.join(__dirname, 'templates', 'spacewalk.njk');
+			program.template = options.template || path.join(
+				__dirname, 'templates', 'spacewalk.njk'
+			);
 		});
 
 	//  Commander.js does an unhelpful thing if there are invalid options;


### PR DESCRIPTION
HTML output was the primary output method in first two UMUC classes. Primary output has since moved to using the npm `docx` library, but uses an inheritance model that should make varying output formats more manageable. This change makes the current `--html` output less broken, but it's still broken. It needs to be moved inside the inheritance model.