### PR TITLE
Make it possible to define steps under joint actors like "EV1 + EV2"

### DIFF
--- a/app/helpers/arrayHelper.js
+++ b/app/helpers/arrayHelper.js
@@ -29,3 +29,26 @@ exports.parseArray = function(yaml) {
 
 	return array;
 };
+
+/**
+ * Determine if all array values (must be integer) are 1 or 0 difference from values before and
+ * after.
+ * @param  {Array} inputArr Array like [1, 2, 3] (returns true) or [1, 3, 5] (returns false) to
+ *                          check for adjacency.
+ * @return {boolean}        Whether or not all items are adjacent
+ */
+exports.allAdjacent = function(inputArr) {
+	return inputArr.reduce((acc, cur, i, arr) => {
+		if (!acc) {
+			return false;
+		}
+		if (i === 0) {
+			return true;
+		}
+		if (Math.abs(cur - arr[i - 1]) > 1) {
+			return false;
+		} else {
+			return true;
+		}
+	}, true);
+};

--- a/app/model/step.js
+++ b/app/model/step.js
@@ -114,6 +114,25 @@ module.exports = class Step {
 
 	}
 
+	/**
+	 * Create a dict taskRolesMap to be able to determine role-->actor. Then
+	 * create function replaceTaskRoles(text) to allow changing text like
+	 * "{{role:crewB}}" into "EV1" if taskRolesMap['crewB'] === 'EV1'
+	 *
+	 * @param  {Object} taskRoles object of TaskRole objects. Example:
+	 *                    taskRoles === {
+	 *                      crewA: TaskRole{
+	 *                        name: 'crewA',
+	 *                        description: 'Crewmember exiting A/L first',
+	 *                        actor: 'EV1'
+	 *                      },
+	 *                      crewB: TaskRole{
+	 *                        name: 'crewB',
+	 *                        description: 'Crewmember exiting A/L second',
+	 *                        actor: 'EV2'
+	 *                      }
+	 *                    }
+	 */
 	mapTaskRolesToActor(taskRoles) {
 		this.taskRoles = taskRoles;
 		const taskRolesMap = {};
@@ -126,6 +145,10 @@ module.exports = class Step {
 			}
 			return text;
 		};
+	}
+
+	setActors(actorIdOrIds) {
+		this.actors = arrayHelper.parseArray(actorIdOrIds);
 	}
 
 	/**

--- a/app/writer/task/EvaDocxTaskWriter.js
+++ b/app/writer/task/EvaDocxTaskWriter.js
@@ -2,6 +2,8 @@
 
 const docx = require('docx');
 const DocxTaskWriter = require('./DocxTaskWriter');
+const arrayHelper = require('../../helpers/arrayHelper');
+const consoleHelper = require('../../helpers/consoleHelper');
 
 module.exports = class EvaDocxTaskWriter extends DocxTaskWriter {
 
@@ -46,20 +48,123 @@ module.exports = class EvaDocxTaskWriter extends DocxTaskWriter {
 	}
 
 	writeDivision(division) {
+		console.log(division);
+		const actorsInDivision = [];
+		const columnsInDivision = [];
+		const columnIndexesInDivision = [];
+		const actorToColumn = {};
+		const actorToColumnIndex = {};
+
+		const jointActors = [];
+
 		for (const actor in division) {
-			// NOTE: aSeries === division[actor]
-			const columnKey = this.procedure.getActorColumnKey(actor);
-			const taskColumnIndex = this.task.getColumnIndex(columnKey);
-			this.writeSeries(this.divisionIndex, taskColumnIndex, division[actor]);
+			if (actor.indexOf('+') === -1) {
+				actorsInDivision.push(actor);
+
+				const columnKey = this.procedure.getActorColumnKey(actor);
+				columnsInDivision.push(columnKey);
+				actorToColumn[actor] = columnKey;
+
+				const taskColumnIndex = this.task.getColumnIndex(columnKey);
+				columnIndexesInDivision.push(taskColumnIndex);
+				actorToColumnIndex[actor] = taskColumnIndex;
+			} else {
+				jointActors.push(actor);
+			}
+		}
+
+		// for holding not just one set of joint actors, but all of them. So if there were two joins
+		// like "EV1 + IV" and "EV2 + SSRMS" we add all of these actors' column keys here
+		const allJointActorColumnKeys = [];
+
+		for (let a = 0; a < jointActors.length; a++) {
+
+			const actors = jointActors[a];
+
+			const actorsArr = actors.split('+').map((str) => {
+				return str.trim();
+			});
+			const jointActorColumnKeys = actorsArr.map((act) => {
+				return this.procedure.getActorColumnKey(act);
+			});
+			const jointActorTaskColumnIndexes = jointActorColumnKeys.map((colKey) => {
+				return this.task.getColumnIndex(colKey);
+			}).sort();
+
+			// check if the columns are adjacent
+			if (!arrayHelper.allAdjacent(jointActorTaskColumnIndexes)) {
+				consoleHelper.error('When joining actors, columns must be adjacent');
+			}
+
+			// compute intersect between allJointActorColumnKeys and jointActorColumnKeys
+			// then compute against columnsInDivision
+			const intersect1 = allJointActorColumnKeys.filter(function(n) {
+				return jointActorColumnKeys.indexOf(n) > -1;
+			});
+			const intersect2 = columnsInDivision.filter(function(n) {
+				return jointActorColumnKeys.indexOf(n) > -1;
+			});
+			if (intersect1.length > 0 || intersect2.length > 0) {
+				intersect1.push(...intersect2);
+				consoleHelper.error(
+					[
+						'For joint actors (e.g. EV1 + EV2), actors cannot be used more than once.',
+						`The following actors used more than once: ${intersect1.toString()}`
+					],
+					'Joint actors error'
+				);
+			}
+			allJointActorColumnKeys.push(...jointActorColumnKeys);
+
+			// save this for later
+			jointActors[a] = {
+				key: actors,
+				array: actorsArr,
+				columnKeys: jointActorColumnKeys,
+				taskColumnIndexes: jointActorTaskColumnIndexes
+			};
+		}
+
+		const columnReMap = {};
+		for (let c = 0; c < this.numCols; c++) {
+			columnReMap[c] = c; // map to itself
+		}
+		console.log(jointActors);
+		// merge the merged columns and write the series' to them
+		for (const actors of jointActors) {
+
+			const firstCol = actors.taskColumnIndexes[0];
+			const lastCol = actors.taskColumnIndexes[actors.taskColumnIndexes.length - 1];
+
+			for (let i = firstCol; i <= lastCol; i++) {
+				columnReMap[i] = firstCol;
+			}
+			const remapDiff = lastCol - firstCol;
+			for (let i = lastCol + 1; i < this.numCols; i++) {
+				columnReMap[i] = i - remapDiff;
+			}
+			this.table.getRow(this.divisionIndex).mergeCells(firstCol, lastCol);
+
+			this.writeSeries(
+				this.divisionIndex,
+				firstCol, // Guessing only able to reference merged columns by first column
+				division[actors.key] // get the division info by the key like "EV1 + EV2"
+			);
+		}
+
+		// write series' the normal columns
+		for (const actor in actorToColumnIndex) {
+			this.writeSeries(this.divisionIndex, actorToColumnIndex[actor], division[actor]);
 		}
 
 		this.table.getRow(this.divisionIndex).setCantSplit();
 
+		// OPTIMIZE for joint actor cases where there are fewer columns
 		for (let c = 0; c < this.numCols; c++) {
-			this.table.getCell(this.divisionIndex, c).Borders.addTopBorder(docx.BorderStyle.SINGLE, 1, 'AAAAAA');
+			this.table.getCell(this.divisionIndex, columnReMap[c]).Borders.addTopBorder(docx.BorderStyle.SINGLE, 1, 'AAAAAA');
 
 			if (this.divisionIndex < this.numRows - 1) {
-				this.table.getCell(this.divisionIndex, c).Borders.addBottomBorder(docx.BorderStyle.SINGLE, 1, 'AAAAAA');
+				this.table.getCell(this.divisionIndex, columnReMap[c]).Borders.addBottomBorder(docx.BorderStyle.SINGLE, 1, 'AAAAAA');
 			}
 		}
 


### PR DESCRIPTION
- Add arrayHelper.allAdjacent() to determine if all array values are adjacent
  (0 is adjacent to 1 but not to 2)
- Make ConcurrentStep pass actor (or actors) to Step. Stored as Step.actors.
  Not 100% sure what this is needed for yet, but injecting actors into
  another actor's procedure this is likely necessary.
- Make ConcurrentStep check for unfilled roles in joint actor situations, so
  when the user-defined "actor" is "crewA + crewB", generate these two vars
  if EV1-->crewA and EV2-->crewB:
    idOrIds = ["EV1 + EV2", "EV1", "EV2"]
    id = "EV1 + EV2"
  and fill them into the concurrent step definition
- EvaDocxTaskWriter.writeDivision() is now _WAY_ more complicated. It likely
  needs some serious simplification. Before it just looped over all actors in
  a division, got the columns they belonged to, then wrote their series. Now it:
  - loops over all actors and either (a) records column info for the solo
    actor or (b) records the actor as a "joint" actor and continues the loop
  - loops over all joint actor groups. One group may be "crewA + SSRMS" and
    another may be "IV + crewB". For each group get the individual actors,
    individual actor column keys, and individual column indexes. Then perform
    some checks.
    - Check 1: Verify all column indexes within a group are adjacent. You
      can't merge cells 1 and 3 in a table.
    - Check 2: Check that this group isn't using columns used by other
      groups. You can't merge columns 1 and 2 and also separately merge 2
      and 3. Need to loop over all groups before this is can be fully
      completed.
    - Check 3: Check that this group isn't using columns used by non-joint
      columns. You can't merge columns 1 and 2, then also have column 2 be an
      individual column.
  - create columnReMap to map column 0 to column 0 by default, but if columns
    1 and 2 are merged (0 and 3 not merged) then this would map:
      0 --> 0
      1 --> 1
      2 --> 1
      3 --> 2
    In other words, one column has effectively been removed.
  - Loop over the joint actors, merge their columns, and adjust the column
    remap. Then write the series.
  - Use the remap to adjust the styling of the cells.